### PR TITLE
feat: replace deprecated jsxBracketSameLine with bracketSameLine

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,7 +5,7 @@
   "singleQuote": true,
   "bracketSpacing": true,
   "jsxSingleQuote": false,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "quoteProps": "consistent",
   "proseWrap": "always",
   "endOfLine": "lf",


### PR DESCRIPTION
From Prettier 2.4.0 jsxBracketSameLine is deprecated. The new property name is bracketSameLine.

https://prettier.io/docs/en/options.html#deprecated-jsx-brackets

This has been emitting a warning in our formatting that we thought we'd get on top of. I'm unsure how this works for backwards compatibility. I guess Prettier will either ignore the option or emit _another_ warning that the property is unrecognised.