### PR TITLE
feat: don't ignore whitespace significance in html contexts

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -11,7 +11,7 @@
   "endOfLine": "lf",
   "arrowParens": "avoid",
   "trailingComma": "none",
-  "htmlWhitespaceSensitivity": "ignore",
+  "htmlWhitespaceSensitivity": "css",
   "overrides": [
     {
       "files": ["*.sass", "*.scss", "*.css", "*.less", "*.html"],


### PR DESCRIPTION
While ignoring whitespace can lead to more consistent formatting, we've started using frameworks like Vue where it is more significant so we've decided to change this