### PR TITLE
feat: use single quotes for sass, scss, css, less, and html

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -11,13 +11,5 @@
   "endOfLine": "lf",
   "arrowParens": "avoid",
   "trailingComma": "none",
-  "htmlWhitespaceSensitivity": "css",
-  "overrides": [
-    {
-      "files": ["*.sass", "*.scss", "*.css", "*.less", "*.html"],
-      "options": {
-        "singleQuote": false
-      }
-    }
-  ]
+  "htmlWhitespaceSensitivity": "css"
 }


### PR DESCRIPTION
These were originally included to help the transition onto using Prettier because the majority of our CSS related code was written in Rails applications where we used double quotes; an unexpected side effect of this was that embedded content (i.e. JavaScript in HTML files) ends up being formatted with double quotes, making it inconsistent with Javascript.

This is expected to be solved someday by having Prettier support being configured based on language rather than filetype, but that is still a long way off and now days Prettier is well established as being our formatter for all things it supports, so I think it's time for us to drop our overrides and just use single quotes for our CSS files too